### PR TITLE
Upgrade node-redis to v3 and remove hiredis

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cache-all",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Fast, efficient cache engines for both express routes cache & native node (redis, in-memory & file cache)",
   "main": "./memory.js",
   "scripts": {
@@ -40,9 +40,8 @@
   "homepage": "https://github.com/bahung1221/cache-all#readme",
   "dependencies": {
     "fs-extra": "^8.1.0",
-    "hiredis": "^0.5.0",
     "lru-cache": "^5.1.1",
-    "redis": "^2.8.0",
+    "redis": "^3.0.2",
     "sanitize-filename": "^1.6.2"
   },
   "devDependencies": {

--- a/readme.md
+++ b/readme.md
@@ -249,6 +249,7 @@ You are welcome <3
 |2.0.6|2019-10-24|Allow redis empty prefix [PR#15](https://github.com/bahung1221/cache-all/pull/15)|
 |2.0.8|2019-10-28|FS async implementation [PR#19](https://github.com/bahung1221/cache-all/pull/19)|
 |2.1.0|2019-10-28|Add type definition (typescript) [PR#22](https://github.com/bahung1221/cache-all/pull/22)|
+|2.1.1|2020-08-05|Upgrade node-redis to `v3` (Removed hiredis completely)|
 
 ## License
 This project is licensed under the terms of the [MIT](https://github.com/bahung1221/cache-all/blob/master/LICENSE) license


### PR DESCRIPTION
`hiredis` was incompatible with node 12, so we must upgrade [node-redis](https://github.com/NodeRedis/node-redis/blob/master/CHANGELOG.md) to v3 to completed remove `hiredis` as a peer dependency